### PR TITLE
Use highp throughout the shaders

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
 
 
 <script id="jellyfish-vs" type="x-shader/x-vertex">
-precision mediump float;
+precision highp float;
 
 attribute vec3 aVertexPosition;
 attribute vec3 aVertexNormal;
@@ -100,7 +100,7 @@ void main(void) {
 </script>
 
 <script id="jellyfish-fs" type="x-shader/x-fragment">
-precision mediump float;
+precision highp float;
 
 uniform sampler2D uSampler0;
 uniform sampler2D uSampler1;


### PR DESCRIPTION
Some systems show artifacts like animation turning choppy over time
(after a few minutes) and corrupted light effects when running the
shaders in mediump. Use highp instead to fix this.
